### PR TITLE
[RFC] Add analytics info to ExoHome Pro IoT Connector template (Issue: SVH: 3988)

### DIFF
--- a/modules/configIO.lua
+++ b/modules/configIO.lua
@@ -33,13 +33,96 @@ function configIO.convertFields(fields)
       end, {})
       :value()
 
+    channels = configIO.combineOtherChannels(channels)
+
     local config_io = to_json({ channels = channels })
-  
+
     return {
       set = config_io,
       reported = config_io,
       timestamp = fields.timestamp
     }
 end
+
+function configIO.combineOtherChannels(channels)
+
+    local protocol_config = {
+      report_rate = 30000,
+      timeout = 30000
+    }
+
+    local properties_number = {
+      control = true,
+      data_type = "NUMBER",
+      locked = true,
+      primitive_type = "NUMERIC"
+    }
+
+    local properties_string = {
+      control = true,
+      data_type = "STRING",
+      locked = true,
+      primitive_type = "STRING"
+    }
+
+    local other_channels = {
+      brand = {
+        display_name = "brand",
+        protocol_config = protocol_config,
+        properties = properties_string
+      },
+      class = {
+        display_name = "class",
+        protocol_config = protocol_config,
+        properties = properties_number
+      },
+      esh_version = {
+        display_name = "esh_version",
+        protocol_config = protocol_config,
+        properties = properties_string
+      },
+      device_id = {
+        display_name = "device_id",
+        protocol_config = protocol_config,
+        properties = properties_string
+      },
+      firmware_version = {
+        display_name = "firmware_version",
+        protocol_config = protocol_config,
+        properties = properties_string
+      },
+      local_ip = {
+        display_name = "local_ip",
+        protocol_config = protocol_config,
+        properties = properties_string
+      },
+      mac_address = {
+        display_name = "mac_address",
+        protocol_config = protocol_config,
+        properties = properties_string
+      },
+      model = {
+        display_name = "model",
+        protocol_config = protocol_config,
+        properties = properties_string
+      },
+      provisioned_time = {
+        display_name = "provisioned_time",
+        protocol_config = protocol_config,
+        properties = properties_number
+      },
+      ssid = {
+        display_name = "ssid",
+        protocol_config = protocol_config,
+        properties = properties_string
+      }
+    }
+
+  local config_io = R.extend(channels, other_channels)
+
+  return config_io
+
+end
+
 
 return configIO

--- a/services/device2.yaml
+++ b/services/device2.yaml
@@ -85,3 +85,9 @@ resources:
         format: string
         settable: false
         unit: ''
+    provisioned_time:
+        allowed: []
+        format: number
+        settable: true
+        sync: false
+        unit: ''

--- a/services/device2/event.lua
+++ b/services/device2/event.lua
@@ -3,18 +3,33 @@
 -- This script handles incoming messages from devices through the Device2 service event.
 -- See http://docs.exosite.com/reference/services/device2/#event.
 
+local configIO = require("configIO")
+local M = require('moses')
 
 log.debug('BEFORE:' .. to_json(event))
+local resources = Device2.getIdentityState({
+  identity = event.identity
+  })
 
-local configIO = require("configIO")
+local esh, module_data, provisioned_time = {}
+
+if resources.provisioned_time ~= nil then
+  esh = from_json(resources.esh.reported)
+  module_data = from_json(resources.module.reported)
+  provisioned_time = { provisioned_time = resources.provisioned_time.set }
+end
+
 if event.payload ~= nil then
   for idx, pl in ipairs(event.payload) do
-    -- copy 'states' to 'data_in' and 'data_out' (for notify UI ack)
+    -- copy 'states' and merge with resources data then transmit to 'data_in' and 'data_out' (for notify UI ack)
     if pl.values['states'] ~= nil then
-      pl.values['data_in'] = pl.values['states']
-      pl.values['data_out'] = pl.values['states']
+      local states = from_json(pl.values['states'])
+      local resources_data = to_json(M.extend(states, esh, module_data, provisioned_time))
+
+      pl.values['data_in'] = resources_data
+      pl.values['data_out'] = resources_data
     end
-    
+
     -- fake config_io data-in, to update exosense config_io cache
     if pl.values['fields'] ~= nil then
       local state = {


### PR DESCRIPTION
Ticket: [https://exosite.atlassian.net/browse/SVH-3988](https://exosite.atlassian.net/browse/SVH-3988)
Add the following data to ExoHome Pro IoT connector template to replace the Exohome analytics page to ExoSense.
- device_id
- brand
- model
- mac_adress
- local_ip
- provisioned_time

