### PR TITLE
ExoHome Pro device IP address needs to be transferred to geolocation (Issue: SVH-4003)

### DIFF
--- a/modules/configIO.lua
+++ b/modules/configIO.lua
@@ -1,10 +1,10 @@
-local R = require('moses')
+local M = require('moses')
 local configIO = {}
 
 function configIO.convertFields(fields)
     local reported = from_json(fields.reported)
 
-    local channels = R(reported)
+    local channels = M(reported)
       :map(function(x)
         if R.isString(x) then
           return {x}
@@ -33,7 +33,7 @@ function configIO.convertFields(fields)
       end, {})
       :value()
 
-    channels = configIO.combineOtherChannels(channels)
+    channels = configIO.combineResourcesChannels(channels)
 
     local config_io = to_json({ channels = channels })
 
@@ -44,97 +44,143 @@ function configIO.convertFields(fields)
     }
 end
 
-function configIO.combineOtherChannels(channels)
+function configIO.combineResourcesChannels(channels)
 
-    local protocol_config = {
-      report_rate = 30000,
-      timeout = 30000
-    }
-
-    local properties_number = {
-      control = true,
-      data_type = "NUMBER",
-      locked = true,
-      primitive_type = "NUMERIC"
-    }
-
-    local properties_string = {
-      control = true,
-      data_type = "STRING",
-      locked = true,
-      primitive_type = "STRING"
-    }
-
-    local properties_location = {
-      data_type = "LOCATION",
-      data_unit = "LAT_LONG",
-      locked = true,
-      primitive_type = "JSON"
-    }
-
-    local other_channels = {
-      brand = {
-        display_name = "brand",
-        protocol_config = protocol_config,
-        properties = properties_string
-      },
-      class = {
-        display_name = "class",
-        protocol_config = protocol_config,
-        properties = properties_number
-      },
-      esh_version = {
-        display_name = "esh_version",
-        protocol_config = protocol_config,
-        properties = properties_string
-      },
-      device_id = {
-        display_name = "device_id",
-        protocol_config = protocol_config,
-        properties = properties_string
-      },
-      firmware_version = {
-        display_name = "firmware_version",
-        protocol_config = protocol_config,
-        properties = properties_string
-      },
-      local_ip = {
-        display_name = "local_ip",
-        protocol_config = protocol_config,
-        properties = properties_string
-      },
-      location = {
-        display_name = "location",
-        protocol_config = protocol_config,
-        properties = properties_location
-      },
-      mac_address = {
-        display_name = "mac_address",
-        protocol_config = protocol_config,
-        properties = properties_string
-      },
-      model = {
-        display_name = "model",
-        protocol_config = protocol_config,
-        properties = properties_string
-      },
-      provisioned_time = {
-        display_name = "provisioned_time",
-        protocol_config = protocol_config,
-        properties = properties_number
-      },
-      ssid = {
-        display_name = "ssid",
-        protocol_config = protocol_config,
-        properties = properties_string
-      }
-    }
-
-  local config_io = R.extend(channels, other_channels)
+  local resources_channels = configIO.resourcesChannels()
+  local config_io = M.extend(channels, resources_channels)
 
   return config_io
 
 end
 
+function configIO.checkCurrentResourcesChannels()
+  local current_resources_channels = Keystore.get({ key = "resources_channels" }).value
+  local new_resources_channels = configIO.resourcesChannels()
+  local resources_channels_changed
+  if current_resources_channels == nil or not M.isEqual(from_json(current_resources_channels), new_resources_channels) then
+    Keystore.set({ key = "resources_channels", value = to_json(new_resources_channels) })
+    resources_channels_changed = true
+  else
+    resources_channels_changed = false
+  end
+  return resources_channels_changed
+end
+
+function configIO.resourcesChannels()
+
+  local protocol_config = {
+    report_rate = 30000,
+    timeout = 30000
+  }
+
+  local properties_number = {
+    control = true,
+    data_type = "NUMBER",
+    locked = true,
+    primitive_type = "NUMERIC"
+  }
+
+  local properties_string = {
+    control = true,
+    data_type = "STRING",
+    locked = true,
+    primitive_type = "STRING"
+  }
+
+  local properties_location = {
+    data_type = "LOCATION",
+    data_unit = "LAT_LONG",
+    locked = true,
+    primitive_type = "JSON"
+  }
+
+  local resources_channels = {
+    brand = {
+      display_name = "brand",
+      protocol_config = protocol_config,
+      properties = properties_string
+    },
+    class = {
+      display_name = "class",
+      protocol_config = protocol_config,
+      properties = properties_number
+    },
+    esh_version = {
+      display_name = "esh_version",
+      protocol_config = protocol_config,
+      properties = properties_string
+    },
+    device_id = {
+      display_name = "device_id",
+      protocol_config = protocol_config,
+      properties = properties_string
+    },
+    firmware_version = {
+      display_name = "firmware_version",
+      protocol_config = protocol_config,
+      properties = properties_string
+    },
+    local_ip = {
+      display_name = "local_ip",
+      protocol_config = protocol_config,
+      properties = properties_string
+    },
+    location = {
+      display_name = "location",
+      protocol_config = protocol_config,
+      properties = properties_location
+    },
+    mac_address = {
+      display_name = "mac_address",
+      protocol_config = protocol_config,
+      properties = properties_string
+    },
+    model = {
+      display_name = "model",
+      protocol_config = protocol_config,
+      properties = properties_string
+    },
+    provisioned_time = {
+      display_name = "provisioned_time",
+      protocol_config = protocol_config,
+      properties = properties_number
+    },
+    ssid = {
+      display_name = "ssid",
+      protocol_config = protocol_config,
+      properties = properties_string
+    }
+  }
+
+  return resources_channels
+end
+
+function configIO.checkOrInitiateCounter(event, resources)
+  local set_config_io_counter
+  if resources.set_config_io_counter == nil then
+    set_config_io_counter = 0
+    Device2.setIdentityState({
+      identity = event.identity,
+      set_config_io_counter = 0
+    })
+  else
+    set_config_io_counter = resources.set_config_io_counter.set
+  end
+  return set_config_io_counter
+end
+
+function configIO.resetCounter(event)
+  Device2.setIdentityState({
+    identity = event.identity,
+    set_config_io_counter = 1
+  })
+end
+
+function configIO.incrementCounter(event, set_config_io_counter)
+  Device2.setIdentityState({
+    identity = event.identity,
+    set_config_io_counter = set_config_io_counter + 1
+  })
+end
 
 return configIO

--- a/modules/configIO.lua
+++ b/modules/configIO.lua
@@ -65,6 +65,13 @@ function configIO.combineOtherChannels(channels)
       primitive_type = "STRING"
     }
 
+    local properties_location = {
+      data_type = "LOCATION",
+      data_unit = "LAT_LONG",
+      locked = true,
+      primitive_type = "JSON"
+    }
+
     local other_channels = {
       brand = {
         display_name = "brand",
@@ -95,6 +102,11 @@ function configIO.combineOtherChannels(channels)
         display_name = "local_ip",
         protocol_config = protocol_config,
         properties = properties_string
+      },
+      location = {
+        display_name = "location",
+        protocol_config = protocol_config,
+        properties = properties_location
       },
       mac_address = {
         display_name = "mac_address",

--- a/modules/ipToGeo.lua
+++ b/modules/ipToGeo.lua
@@ -4,10 +4,15 @@ function ipToGeo.convertIP(ip)
 	local ret = Geo.ipToGeo({
 		ip = ip
 	})
-	local latitude = ret.value.coordinates[2]
-	local longitude = ret.value.coordinates[1]
-	local location = { location = to_json({ lat = latitude, lng = longitude }) }
-	return location
+	if ret.error ~= nil then
+  		log.debug(to_json(ret))
+  		return nil
+	else
+		local latitude = ret.value.coordinates[2]
+		local longitude = ret.value.coordinates[1]
+		local location = { location = to_json({ lat = latitude, lng = longitude }) }
+		return location
+	end
 end
 
 return ipToGeo

--- a/modules/ipToGeo.lua
+++ b/modules/ipToGeo.lua
@@ -1,0 +1,13 @@
+local ipToGeo = {}
+
+function ipToGeo.convertIP(ip)
+	local ret = Geo.ipToGeo({
+		ip = ip
+	})
+	local latitude = ret.value.coordinates[2]
+	local longitude = ret.value.coordinates[1]
+	local location = { location = to_json({ lat = latitude, lng = longitude }) }
+	return location
+end
+
+return ipToGeo

--- a/services/device2.yaml
+++ b/services/device2.yaml
@@ -93,6 +93,12 @@ resources:
         format: string
         settable: true
         unit: ''
+    set_config_io_counter:
+        allowed: []
+        format: number
+        settable: true
+        sync: false
+        unit: ''
     states:
         allowed: []
         format: string

--- a/services/device2/event.lua
+++ b/services/device2/event.lua
@@ -8,45 +8,64 @@ local M = require('moses')
 log.debug('BEFORE:' .. to_json(event))
 local resources = Device2.getIdentityState({
   identity = event.identity
-  })
-
-local location = ipToGeo.convertIP(event.ip)
-
-local esh, module_data, provisioned_time = {}
-local fields
-
-if resources.provisioned_time ~= nil then
-  esh = from_json(resources.esh.reported)
-  module_data = from_json(resources.module.reported)
-  provisioned_time = { provisioned_time = resources.provisioned_time.set }
-  fields = resources.fields.reported
-end
+})
 
 if event.payload ~= nil then
   for idx, pl in ipairs(event.payload) do
-    -- copy 'states' and merge with resources data then transmit to 'data_in' and 'data_out' (for notify UI ack)
+    -- Copy 'states' and merge with resources data then transmit to 'data_in' and 'data_out' (for notify UI ack)
     if pl.values['states'] ~= nil then
+
       local states = from_json(pl.values['states'])
+      local esh, module_data, provisioned_time = {}
+      local fields
+      if resources.provisioned_time ~= nil then
+        esh = from_json(resources.esh.reported)
+        module_data = from_json(resources.module.reported)
+        provisioned_time = { provisioned_time = resources.provisioned_time.set }
+        fields = resources.fields.reported
+      end
+
+      local location = ipToGeo.convertIP(event.ip)
       local resources_data = to_json(M.extend(states, esh, module_data, provisioned_time, location ))
-      log.debug(resources_data)
+
       pl.values['data_in'] = resources_data
       pl.values['data_out'] = resources_data
+
+      -- Fake config_io data-in to update exosense config_io cache when detected config_io changed
+      if fields ~= nil then
+
+        local set_config_io_counter
+        set_config_io_counter = configIO.checkOrInitiateCounter(event, resources)
+
+        local state = {
+          set = fields,
+          reported = fields,
+          timestamp = pl.timestamp
+        }
+        local config_io = configIO.convertFields(state).reported
+
+        local config_io_changed = configIO.checkCurrentResourcesChannels()
+        if config_io_changed == true then
+          log.debug('Set new config_io')
+          pl.values['config_io'] = config_io
+          configIO.resetCounter(event)
+        elseif set_config_io_counter <= 2 then -- Only allow sending config_io twice after set config_io
+          pl.values['config_io'] = config_io
+          configIO.incrementCounter(event, set_config_io_counter)
+        end
+      end
     end
 
-    -- fake config_io data-in, to update exosense config_io cache
-    if fields ~= nil then
-      local origin_config_io = Keystore.get({ key = "config_io" }).value
+    -- Fake config_io data-in to update exosense config_io cache when provisioned
+    if pl.values['fields'] ~= nil then
+      log.debug('Set config_io when provisioned')
       local state = {
-        set = fields,
-        reported = fields,
+        set = pl.values['fields'],
+        reported = pl.values['fields'],
         timestamp = pl.timestamp
       }
-      local new_config_io = configIO.convertFields(state).reported
-      if origin_config_io == nil or origin_config_io ~= new_config_io then
-        log.debug('Set new config_io')
-        Keystore.set({ key = "config_io", value = new_config_io })
-        pl.values['config_io'] = new_config_io
-      end
+      local config_io = configIO.convertFields(state).reported
+      pl.values['config_io'] = config_io
     end
   end
 end

--- a/services/device2/event.lua
+++ b/services/device2/event.lua
@@ -1,9 +1,8 @@
 --#EVENT device2 event
-
 -- This script handles incoming messages from devices through the Device2 service event.
 -- See http://docs.exosite.com/reference/services/device2/#event.
-
 local configIO = require("configIO")
+local ipToGeo = require("ipToGeo")
 local M = require('moses')
 
 log.debug('BEFORE:' .. to_json(event))
@@ -11,12 +10,16 @@ local resources = Device2.getIdentityState({
   identity = event.identity
   })
 
+local location = ipToGeo.convertIP(event.ip)
+
 local esh, module_data, provisioned_time = {}
+local fields
 
 if resources.provisioned_time ~= nil then
   esh = from_json(resources.esh.reported)
   module_data = from_json(resources.module.reported)
   provisioned_time = { provisioned_time = resources.provisioned_time.set }
+  fields = resources.fields.reported
 end
 
 if event.payload ~= nil then
@@ -24,28 +27,33 @@ if event.payload ~= nil then
     -- copy 'states' and merge with resources data then transmit to 'data_in' and 'data_out' (for notify UI ack)
     if pl.values['states'] ~= nil then
       local states = from_json(pl.values['states'])
-      local resources_data = to_json(M.extend(states, esh, module_data, provisioned_time))
-
+      local resources_data = to_json(M.extend(states, esh, module_data, provisioned_time, location ))
+      log.debug(resources_data)
       pl.values['data_in'] = resources_data
       pl.values['data_out'] = resources_data
     end
 
     -- fake config_io data-in, to update exosense config_io cache
-    if pl.values['fields'] ~= nil then
+    if fields ~= nil then
+      local origin_config_io = Keystore.get({ key = "config_io" }).value
       local state = {
-        set = pl.values['fields'],
-        reported = pl.values['fields'],
+        set = fields,
+        reported = fields,
         timestamp = pl.timestamp
       }
-      local converted = configIO.convertFields(state)
-      pl.values['config_io'] = converted.reported
+      local new_config_io = configIO.convertFields(state).reported
+      if origin_config_io == nil or origin_config_io ~= new_config_io then
+        log.debug('Set new config_io')
+        Keystore.set({ key = "config_io", value = new_config_io })
+        pl.values['config_io'] = new_config_io
+      end
     end
   end
 end
 
 log.debug('AFTER: ' .. to_json(event))
 
-return Interface.trigger({event="event", data=event})
+return Interface.trigger({ event = "event", data = event})
 -- Above line forward device data to all Murano Applications connected to this Product
 -- To send data to a specific Application, use the 'triggerOne' operation.
 -- See http://docs.exosite.com/reference/services/interface/#triggerone.


### PR DESCRIPTION
Ticket: [https://exosite.atlassian.net/browse/SVH-4003](https://exosite.atlassian.net/browse/SVH-4003)

1. Transfer the device IP to geo location.
2. Send new config_io to ExoSense twice if there is any change of config_io(Ex: Resources change or H keys change).
    * If the asset is not created, config_io needs to be sent at least twice to keep the data_in showing on device overview page.
    * If the asset is created, config_io just need to be sent once to keep the data_in showing on device overview page.
    * In conclusion, send config_io twice anyways if any change of config_io. 
3. Send config_io to ExoSense once If the device is provisioned first time. 